### PR TITLE
Feature/OS-13 Sandbox integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .metals
 .bloop
 
-metadefender-plugin.zip
+metadefender-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .vscode
 .metals
 .bloop
+**/target
 
 metadefender-*.zip

--- a/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -1,102 +1,130 @@
 <%@ include file="/include.jsp" %>
 
-<form action="/app/metadefender/config" method="post">
-    <table class="runnerFormTable">
-        <tbody>
-            <tr class="groupingTitle">
-                <td colspan="2">MetaDefender Configuration</td>
-            </tr><tr>
-                <td class="grayNote" colspan="2">
-                    Configure MetaDefender REST and API key for scans.
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mURL">MetaDefender URL</label>
-                </td><td>
-                    <input type="text" id="mURL" name="mURL" value="${mURL}" class="longField">
-                    <div class="grayNote">e.g.: https://api.metadefender.com/v4/file <br> or http://&lt;MetaDefender Core V4 IP address&gt;:8008/file <br> or http://&lt;MetaDefender Core V3 IP address&gt;:8008/metascan_rest/file</div>
-                </td>
-            </tr><tr>
-                <td>
-                    <label for="mAPIKey">API key</label>
-                </td><td>
-                    <input type="text" id="mAPIKey" name="mAPIKey" value="${mAPIKey}" class="longField">
-                </td>
-            </tr>
-            <tr>
-                 <td>
-                     <label for="mTimeOut">Scan timeout</label>
-                 </td><td>
-                     <input type="text" id="mTimeOut" name="mTimeOut" value="${mTimeOut}"> mins
-                     <div class="grayNote">Enter scan timeout per file (default is 30 mins)</div>
-                 </td>
-            </tr>
-            <tr>
-                 <td>
-                     <label for="mForceScan">Scan automatically when build runs</label>
-                 </td><td>
-                     <input type="checkbox" id="mForceScan" name="mForceScan" ${mForceScan} value="checked">
-                 </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mViewDetail">Display scan result link</label>
-                </td><td>
-                    <input type="checkbox" id="mViewDetail" name="mViewDetail" ${mViewDetail} value="checked">
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mSandboxEnabled">Analyze files automatically with Sandbox</label>
-                </td><td>
-                    <input type="checkbox" id="mSandboxEnabled" name="mSandboxEnabled" ${mSandboxEnabled} value="checked">
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mSandboxOS">Sandbox operating system</label>
-                </td><td>
-                    <input type="text" id="mSandboxOS" name="mSandboxOS" value="${mSandboxOS}">
-                    <div class="grayNote">Possible values: windows7 or windows10</div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mSandboxTimeOut">Sandbox analysis timeout</label>
-                </td><td>
-                    <input type="text" id="mSandboxTimeOut" name="mSandboxTimeOut" value="${mSandboxTimeOut}">
-                    <div class="grayNote">Possible values: short or long (short=150s, long=300s)</div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label for="mSandboxBrowser">Sandbox browser to use during analysis</label>
-                </td><td>
-                    <input type="text" id="mSandboxBrowser" name="mSandboxBrowser" value="${mSandboxBrowser}">
-                    <div class="grayNote">Possible values: os_default, chrome or firefox</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2">
-                <br>
-                     To set different options for a particular build, you can set the following system properties in the Build Configuration Parameters: <br>
-                     <b> system.metadefender_scan_artifact</b> - If set to 1, the artifact will automatically be scanned when the build runs. The default value is 0.<br>
-                     <b> system.metadefender_scan_log</b> - If set to 1, the scan log metadefender_scan_log.txt will be created in the artifact folder. The default value is 0.<br>
-                     <b> system.metadefender_fail_build</b> - If set to 1, and a threat is found the build will automatically fail. The default value is 1.<br>
-                     <b> system.metadefender_scan_timeout</b> - Enter time out for one file in mins<br>
-                     <b> system.metadefender_scan_artifact_with_sandbox</b> - If set to 1, the artifact will automatically be analyzed by Sandbox when the build runs. The default value is 0.<br>
-                     <b> system.metadefender_sandbox_os</b> - Set the Sandbox operating system: windows7 or windows10. The default value is windows10.<br>
-                     <b> system.metadefender_sandbox_timeout</b> - Set the Sandbox analysis timeout: short (150s) or long (300s). The default value is short.<br>
-                     <b> system.metadefender_sandbox_browser</b> - Set the Sandbox browser to use during analysis: os_default, chrome or firefox. The default value is os_default.<br>
-                     <i>Note that specifying system properties in the build parameters will override the global options. If you wish to use the global settings for the build, do not enter any system properties.</i>
-                     <br>
-                     <br>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <label for="mFailBuild" style="display:none">Fail build when issue is found</label>
-    <input style="display:none" type="checkbox" id="mFailBuild" name="mFailBuild" ${mFailBuild} value="checked">
-    <input type="submit" class="btn btn-default" value="Save">
-</form>
+    <form action="/app/metadefender/config" method="post">
+        <table class="runnerFormTable">
+            <tbody>
+                <tr class="groupingTitle">
+                    <td colspan="2">MetaDefender Configuration</td>
+                </tr>
+                <tr>
+                    <td class="grayNote" colspan="2">
+                        Configure MetaDefender REST and API key for scans.
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mURL">MetaDefender URL</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mURL" name="mURL" value="${mURL}" class="longField">
+                        <div class="grayNote">e.g.: https://api.metadefender.com/v4/file <br> or http://&lt;MetaDefender
+                            Core V4 IP address&gt;:8008/file <br> or http://&lt;MetaDefender Core V3 IP
+                            address&gt;:8008/metascan_rest/file</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mAPIKey">API key</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mAPIKey" name="mAPIKey" value="${mAPIKey}" class="longField">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mTimeOut">Scan timeout</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mTimeOut" name="mTimeOut" value="${mTimeOut}"> mins
+                        <div class="grayNote">Enter scan timeout per file (default is 30 mins)</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mForceScan">Scan automatically when build runs</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="mForceScan" name="mForceScan" ${mForceScan} value="checked">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mViewDetail">Display scan result link</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="mViewDetail" name="mViewDetail" ${mViewDetail} value="checked">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mSandboxEnabled">Analyze files automatically with Sandbox (MetaDefender Cloud
+                            only)</label>
+                    </td>
+                    <td>
+                        <input type="checkbox" id="mSandboxEnabled" name="mSandboxEnabled" ${mSandboxEnabled}
+                            value="checked">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mSandboxOS">Sandbox operating system (MetaDefender Cloud only)</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mSandboxOS" name="mSandboxOS" value="${mSandboxOS}">
+                        <div class="grayNote">Possible values: windows7 or windows10</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mSandboxTimeOut">Sandbox analysis timeout (MetaDefender Cloud only)</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mSandboxTimeOut" name="mSandboxTimeOut" value="${mSandboxTimeOut}">
+                        <div class="grayNote">Possible values: short or long (short=150s, long=300s)</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label for="mSandboxBrowser">Sandbox browser to use during analysis (MetaDefender Cloud
+                            only)</label>
+                    </td>
+                    <td>
+                        <input type="text" id="mSandboxBrowser" name="mSandboxBrowser" value="${mSandboxBrowser}">
+                        <div class="grayNote">Possible values: os_default, chrome or firefox</div>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="2">
+                        <br>
+                        To set different options for a particular build, you can set the following system properties in
+                        the Build Configuration Parameters: <br>
+                        <b> system.metadefender_scan_artifact</b> - If set to 1, the artifact will automatically be
+                        scanned when the build runs. The default value is 0.<br>
+                        <b> system.metadefender_scan_log</b> - If set to 1, the scan log metadefender_scan_log.txt will
+                        be created in the artifact folder. The default value is 0.<br>
+                        <b> system.metadefender_fail_build</b> - If set to 1, and a threat is found the build will
+                        automatically fail. The default value is 1.<br>
+                        <b> system.metadefender_scan_timeout</b> - Enter time out for one file in mins<br>
+                        <b> system.metadefender_scan_artifact_with_sandbox</b> - If set to 1, the artifact will
+                        automatically be analyzed by Sandbox when the build runs. The default value is 0.<br>
+                        <b> system.metadefender_sandbox_os</b> - Set the Sandbox operating system: windows7 or
+                        windows10. The default value is windows10.<br>
+                        <b> system.metadefender_sandbox_timeout</b> - Set the Sandbox analysis timeout: short (150s) or
+                        long (300s). The default value is short.<br>
+                        <b> system.metadefender_sandbox_browser</b> - Set the Sandbox browser to use during analysis:
+                        os_default, chrome or firefox. The default value is os_default.<br>
+                        <i>Note that Sandbox analysis only works with MetaDefender Cloud (the MetaDefender URL parameter
+                            must include "api.metadefender.com").</i><br>
+                        <i>Note that specifying system properties in the build parameters will override the global
+                            options. If you wish to use the global settings for the build, do not enter any system
+                            properties.</i>
+                        <br>
+                        <br>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <label for="mFailBuild" style="display:none">Fail build when issue is found</label>
+        <input style="display:none" type="checkbox" id="mFailBuild" name="mFailBuild" ${mFailBuild} value="checked">
+        <input type="submit" class="btn btn-default" value="Save">
+    </form>

--- a/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -48,9 +48,33 @@
             </tr>
             <tr>
                 <td>
-                    <label for="mSandbox">Analyze files with sandbox</label>
+                    <label for="mSandboxEnabled">Analyze files automatically with Sandbox</label>
                 </td><td>
-                    <input type="checkbox" id="mSandbox" name="mSandbox" ${mSandbox} value="checked">
+                    <input type="checkbox" id="mSandboxEnabled" name="mSandboxEnabled" ${mSandboxEnabled} value="checked">
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="mSandboxOS">Sandbox operating system</label>
+                </td><td>
+                    <input type="text" id="mSandboxOS" name="mSandboxOS" value="${mSandboxOS}">
+                    <div class="grayNote">Possible values: windows7 or windows10</div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="mSandboxTimeOut">Sandbox analysis timeout</label>
+                </td><td>
+                    <input type="text" id="mSandboxTimeOut" name="mSandboxTimeOut" value="${mSandboxTimeOut}">
+                    <div class="grayNote">Possible values: short or long (short=150s, long=300s)</div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <label for="mSandboxBrowser">Sandbox browser to use during analysis</label>
+                </td><td>
+                    <input type="text" id="mSandboxBrowser" name="mSandboxBrowser" value="${mSandboxBrowser}">
+                    <div class="grayNote">Possible values: os_default, chrome or firefox</div>
                 </td>
             </tr>
             <tr>

--- a/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -39,7 +39,7 @@
                      <input type="checkbox" id="mForceScan" name="mForceScan" ${mForceScan} value="checked">
                  </td>
             </tr>
-			<tr>
+            <tr>
                 <td>
                     <label for="mViewDetail">Display scan result link</label>
                 </td><td>
@@ -55,20 +55,20 @@
             </tr>
             <tr>
                 <td colspan="2">
-				<br>
+                <br>
                      To set different options for a particular build, you can set the following system properties in the Build Configuration Parameters: <br>
                      <b> system.metadefender_scan_artifact</b> - If set to 1, the artifact will automatically be scanned when the build runs. The default value is 0.<br>
                      <b> system.metadefender_scan_log</b> - If set to 1, the scan log metadefender_scan_log.txt will be created in the artifact folder. The default value is 0.<br>
                      <b> system.metadefender_fail_build</b> - If set to 1, and a threat is found the build will automatically fail. The default value is 1.<br>
                      <b> system.metadefender_scan_timeout</b> - Enter time out for one file in mins<br>
-					 <i>Note that specifying system properties in the build parameters will override the global options. If you wish to use the global settings for the build, do not enter any system properties.</i>
-					 <br>
-					 <br>
+                     <i>Note that specifying system properties in the build parameters will override the global options. If you wish to use the global settings for the build, do not enter any system properties.</i>
+                     <br>
+                     <br>
                 </td>
             </tr>
         </tbody>
     </table>
-	<label for="mFailBuild" style="display:none">Fail build when issue is found</label>
-	<input style="display:none" type="checkbox" id="mFailBuild" name="mFailBuild" ${mFailBuild} value="checked">
+    <label for="mFailBuild" style="display:none">Fail build when issue is found</label>
+    <input style="display:none" type="checkbox" id="mFailBuild" name="mFailBuild" ${mFailBuild} value="checked">
     <input type="submit" class="btn btn-default" value="Save">
 </form>

--- a/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/metadefender-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -85,6 +85,10 @@
                      <b> system.metadefender_scan_log</b> - If set to 1, the scan log metadefender_scan_log.txt will be created in the artifact folder. The default value is 0.<br>
                      <b> system.metadefender_fail_build</b> - If set to 1, and a threat is found the build will automatically fail. The default value is 1.<br>
                      <b> system.metadefender_scan_timeout</b> - Enter time out for one file in mins<br>
+                     <b> system.metadefender_scan_artifact_with_sandbox</b> - If set to 1, the artifact will automatically be analyzed by Sandbox when the build runs. The default value is 0.<br>
+                     <b> system.metadefender_sandbox_os</b> - Set the Sandbox operating system: windows7 or windows10. The default value is windows10.<br>
+                     <b> system.metadefender_sandbox_timeout</b> - Set the Sandbox analysis timeout: short (150s) or long (300s). The default value is short.<br>
+                     <b> system.metadefender_sandbox_browser</b> - Set the Sandbox browser to use during analysis: os_default, chrome or firefox. The default value is os_default.<br>
                      <i>Note that specifying system properties in the build parameters will override the global options. If you wish to use the global settings for the build, do not enter any system properties.</i>
                      <br>
                      <br>

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
@@ -165,19 +165,16 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                 if (sandboxOS == "") {
                   sandboxOS = "windows10"
                 }
-                reportInfo("sandbox OS: " + sandboxOS)
                 post.setHeader("sandbox", sandboxOS)
 
                 val sandboxTimeOut =
                   getBuildParameter("system.metadefender_sandbox_timeout", config.mSandboxTimeOut.mkString)
-                reportInfo("sandbox timeout: " + sandboxTimeOut)
                 if (sandboxTimeOut != "") {
                   post.setHeader("sandbox_timeout", sandboxTimeOut)
                 }
 
                 val sandboxBrowser =
                   getBuildParameter("system.metadefender_sandbox_browser", config.mSandboxBrowser.mkString)
-                reportInfo("sandbox browser: " + sandboxBrowser)
                 if (sandboxBrowser != "") {
                   post.setHeader("sandbox_browser", sandboxBrowser)
                 }
@@ -209,15 +206,6 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                     URL = "https://" + sRestIP + "/file"
                   } else {
                     URL = "http://" + sRestIP + "/file"
-                  }
-                }
-                if (sandboxEnabled) {
-                  val sSandboxID: String = jsonAst.asJsObject.fields.get("sandbox_id") match {
-                    case Some(x: JsString) => x.value
-                    case _                 => null
-                  }
-                  if (sSandboxID != null) {
-                    reportInfo("sandbox_id: " + sSandboxID)
                   }
                 }
                 val get = new HttpGet(URL + "/" + sDataID)

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
@@ -145,7 +145,7 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
               if (config.mAPIKey.mkString != "") {
                 post.setHeader("apikey", config.mAPIKey.mkString)
               }
-              val sandboxEnabled = (config.mSandbox.mkString == "checked")
+              val sandboxEnabled = (config.mSandboxEnabled.mkString == "checked")
               if (sandboxEnabled) {
                 post.setHeader("sandbox", "windows10")
                 // A scan rule is needed to also trigger multiscanning

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
@@ -45,7 +45,7 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
     var totalFileInArchive = 0
 
     var viewDetailsPrefix = ""
-    var maxScanTimeSecond = 30 * 2 * 60
+    var maxScanTimeSecond = 30 * 60
     val totalThread = 10
     var finishedThread = 0
 
@@ -54,9 +54,9 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
       //set Scan timeout
       val timeout = runningBuild.getParametersProvider.get("system.metadefender_scan_timeout")
       if (timeout == "" || !Try(timeout.toInt).isSuccess)
-        maxScanTimeSecond = config.mTimeOut.mkString.toInt * 2 * 60
+        maxScanTimeSecond = config.mTimeOut.mkString.toInt * 60
       else
-        maxScanTimeSecond = timeout.toInt * 2 * 60 //Sleep 500ms only
+        maxScanTimeSecond = timeout.toInt * 60
 
       //set Scan URL, it's kind of complicated checks dues to supported Core versions
       val URL = config.mURL.mkString
@@ -190,16 +190,16 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
 
                 var scanProgressPercentage: BigDecimal = 0
                 var processProgressPercentage: BigDecimal = 0
-                var timeOut = 0
+                var startTime: BigDecimal = System.currentTimeMillis()
+                var runTimeSeconds: BigDecimal = 0
                 var scanAllResultI: BigDecimal = -1
                 var scanResults: JsObject = JsObject()
                 var processInfo: JsObject = JsObject()
 
                 //Query scan result
                 while (
-                  (scanProgressPercentage != 100 || processProgressPercentage != 100) && timeOut < maxScanTimeSecond
+                  (scanProgressPercentage != 100 || processProgressPercentage != 100) && runTimeSeconds < maxScanTimeSecond
                 ) {
-                  timeOut += 1
                   response = httpClient.execute(get)
                   if (response.getStatusLine.getStatusCode == 200) {
                     jsonReturn = Source.fromInputStream(response.getEntity.getContent)("UTF-8").mkString
@@ -234,6 +234,8 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                       case Some(x: JsNumber) => x.value
                       case _                 => throw new Exception("Error scan_all_result_i json: " + jsonReturn)
                     }
+
+                    Thread.sleep(500)
                   } else {
                     response.getEntity().consumeContent();
                     val tm = s"Scan error, code " + response.getStatusLine.getStatusCode + s" file: " + fileToLog
@@ -241,12 +243,14 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                     lockerOtherFiles.synchronized {
                       otherFiles = tm :: otherFiles
                     }
+
+                    Thread.sleep(5000)
                   }
-                  Thread.sleep(500)
+                  runTimeSeconds = (System.currentTimeMillis() - startTime) / 1000
                 }
 
                 //Checking scan result i
-                if (timeOut >= maxScanTimeSecond) {
+                if (runTimeSeconds >= maxScanTimeSecond) {
                   reportError("Time out file: " + fileToLog)
                 } else {
 
@@ -334,10 +338,8 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                   /*Check file inside archive*/
                   jsonAst.asJsObject.fields.get("extracted_files") match {
                     case Some(extractedFiles: JsObject) =>
-                      extractedFiles;
                       extractedFiles.fields.get("files_in_archive") match {
                         case Some(filesInArchive: JsArray) =>
-                          filesInArchive
                           val totalFile = filesInArchive.elements.size
                           for (i <- 0 until totalFile) {
                             val t = filesInArchive.elements.apply(i)
@@ -414,7 +416,7 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
     ) {
       reportInfo("Scanning artifacts")
       prepareConfigs()
-      reportInfo("Scan timeout: " + maxScanTimeSecond / 2 + " (s)")
+      reportInfo("Scan timeout: " + maxScanTimeSecond + " (s)")
       getAllFiles(runningBuild).foreach { case (name: String, artifact: File) =>
         //Push all files to list, do not put those folders such as
         //C:\ProgramData\JetBrains\TeamCity\system\artifacts\Test\tt\38\.teamcity\logs\buildLog.msg5

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/ArtifactScanner.scala
@@ -157,7 +157,9 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
 
               val buildParams = runningBuild.getParametersProvider
               val sandboxEnabled = (buildParams.get("system.metadefender_scan_artifact_with_sandbox") == "1" ||
-                config.mSandboxEnabled.mkString == "checked")
+                (buildParams.get("system.metadefender_scan_artifact_with_sandbox") != "0" &&
+                  config.mSandboxEnabled.mkString == "checked")) &&
+                  (URL contains "api.metadefender.com")
 
               if (sandboxEnabled) {
                 var sandboxOS =
@@ -348,7 +350,10 @@ class ArtifactScanner(config: MConfigManager) extends BuildServerAdapter {
                         infectedFiles = tm :: infectedFiles
                       }
                     } else if (processResult.toLowerCase.equals("allowed")) {
-                      reportInfo(tm)
+                      //The user should see the link to all scan reports if Sandbox is enabled
+                      if (sandboxEnabled) {
+                        reportInfo(tm)
+                      }
                       lockerCleanFiles.synchronized {
                         cleanFiles = tm :: cleanFiles
                       }

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/MConfigController.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/MConfigController.scala
@@ -30,7 +30,10 @@ class MConfigController(config: MConfigManager, webControllerManager: WebControl
         checkbox("mForceScan"),
         checkbox("mFailBuild"),
         param("mTimeOut"),
-        checkbox("mSandbox")
+        checkbox("mSandboxEnabled"),
+        param("mSandboxOS"),
+        param("mSandboxTimeOut"),
+        param("mSandboxBrowser")
       )
     )
 

--- a/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/MConfigManager.scala
+++ b/metadefender-plugin-server/src/main/scala/com/opswat/teamcity/MConfigManager.scala
@@ -15,7 +15,10 @@ case class MConfig(
     mForceScan: Option[String],
     mFailBuild: Option[String],
     mTimeOut: Option[String],
-    mSandbox: Option[String]
+    mSandboxEnabled: Option[String],
+    mSandboxOS: Option[String],
+    mSandboxTimeOut: Option[String],
+    mSandboxBrowser: Option[String]
 )
 
 class MConfigManager(paths: ServerPaths) {
@@ -39,7 +42,10 @@ class MConfigManager(paths: ServerPaths) {
       return Option("30")
     return config.flatMap(_.mTimeOut)
   }
-  def mSandbox: Option[String] = config.flatMap(_.mSandbox)
+  def mSandboxEnabled: Option[String] = config.flatMap(_.mSandboxEnabled)
+  def mSandboxOS: Option[String] = config.flatMap(_.mSandboxOS)
+  def mSandboxTimeOut: Option[String] = config.flatMap(_.mSandboxTimeOut)
+  def mSandboxBrowser: Option[String] = config.flatMap(_.mSandboxBrowser)
 
   private[teamcity] def update(config: MConfig): Unit = {
     this.config = Some(config)
@@ -61,7 +67,10 @@ class MConfigManager(paths: ServerPaths) {
     "mForceScan" -> mForceScan,
     "mFailBuild" -> mFailBuild,
     "mTimeOut" -> mTimeOut,
-    "mSandbox" -> mSandbox
+    "mSandboxEnabled" -> mSandboxEnabled,
+    "mSandboxOS" -> mSandboxOS,
+    "mSandboxTimeOut" -> mSandboxTimeOut,
+    "mSandboxBrowser" -> mSandboxBrowser
   )
 
 }


### PR DESCRIPTION
Added Sandbox integration to the artifact scanning. 
The user can specify the Sandbox options globally in the plugin's configuration page or individually for each build using the following build parameters:

- `system.metadefender_scan_artifact_with_sandbox`
- `system.metadefender_sandbox_os`
- `system.metadefender_sandbox_timeout`
- `system.metadefender_sandbox_browser`

Note that analyzing archives is not supported by Sandbox.